### PR TITLE
additions to support VO integration with Pronto

### DIFF
--- a/cmake/pods.cmake
+++ b/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.09.21
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -305,19 +307,17 @@ macro(pods_use_pkg_config_packages target)
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
         OUTPUT_VARIABLE _pods_pkg_ldflags)
     string(STRIP ${_pods_pkg_ldflags} _pods_pkg_ldflags)
-    # message("ldflags: ${_pods_pkg_ldflags}")
+    #    message("ldflags: ${_pods_pkg_ldflags}")
     include_directories(${_pods_pkg_include_flags})
-    string(REPLACE " " ";" TMP ${_pods_pkg_ldflags}) #covert to a list
-    target_link_libraries(${target} ${TMP})
+    target_link_libraries(${target} ${_pods_pkg_ldflags})
     
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
-                    #message("---- ${target} depends on  ${__depend_target_name}")
+                if(TARGET "${__depend_target_name}")
+                    #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
         endforeach()

--- a/src/fovision/CMakeLists.txt
+++ b/src/fovision/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable (se-simple-fusion fovision_fusion.cpp)
 target_link_libraries(se-simple-fusion boost_system)
 pods_use_pkg_config_packages(se-simple-fusion eigen3
   lcm bot2-core bot2-frames   bot2-frames_cpp
-  lcmtypes_bot2-core  lcmtypes_fovis-bot2 lcmtypes_microstrain zlib
+  lcmtypes_bot2-core  lcmtypes_fovis-bot2 zlib
   voconfig   vofeatures   voestimator   fovision
   pronto_vis  
   opencv image_io_utils
@@ -43,7 +43,7 @@ add_executable (se-simple-vo fovision_vo.cpp)
 target_link_libraries(se-simple-vo boost_system)
 pods_use_pkg_config_packages(se-simple-vo eigen3 
   lcm bot2-core bot2-frames   bot2-frames_cpp
-  lcmtypes_bot2-core  lcmtypes_fovis-bot2 lcmtypes_microstrain zlib
+  lcmtypes_bot2-core  lcmtypes_fovis-bot2 zlib
   voconfig   vofeatures   voestimator   fovision
   pronto_vis  
   opencv image_io_utils

--- a/src/fovision/fovision.hpp
+++ b/src/fovision/fovision.hpp
@@ -13,11 +13,11 @@
 
 #include <lcm/lcm-cpp.hpp>
 
-#include <lcmtypes/bot_core.h>
 #include <fovis/fovis.hpp>
 
-#include <lcmtypes/fovis_stats_t.h>
-#include <lcmtypes/fovis_update_t.h>
+#include <lcmtypes/bot_core/pose_t.hpp>
+#include <lcmtypes/fovis/stats_t.hpp>
+#include <lcmtypes/fovis/update_t.hpp>
 
 #include <bot_lcmgl_client/lcmgl.h>
 #include "visualization.hpp"
@@ -41,6 +41,9 @@ public:
     void doOdometry(uint8_t *left_buf,float *disparity_buf, int64_t utime);
 
     void send_status_msg(std::string text);
+
+    fovis::update_t get_delta_translation_msg(Eigen::Isometry3d motion_estimate,
+      Eigen::MatrixXd motion_cov, int64_t timestamp, int64_t prev_timestamp);
     
     void send_delta_translation_msg(Eigen::Isometry3d motion_estimate,
       Eigen::MatrixXd motion_cov, std::string channel_name);

--- a/src/fovision/fovision_vo.cpp
+++ b/src/fovision/fovision_vo.cpp
@@ -275,9 +275,10 @@ Eigen::Isometry3d getBotTransAsPose(BotTrans msgT){
 
 
 Eigen::Isometry3d Isometry_invert_and_compose(Eigen::Isometry3d curr, Eigen::Isometry3d prev){
-  // this function isn't stable or doesnt work as envisaged... TODO: really need to solve this
-  // perhaps with Affine instead
-  //  Eigen::Isometry3d delta_body_from_ref =  world_to_body_ * ( ref_body_pose_.inverse() );
+  // the typical Isometry3d transformation I have used isn't stable or doesnt work as envisaged...
+  // Eigen::Isometry3d delta_body_from_ref =  world_to_body_ * ( ref_body_pose_.inverse() );
+  // TODO: really need to solve this, perhaps with Affine instead
+  // In the meantime the BotTrans calculations used here are consistent with libbot
 
   BotTrans curr_BT = getPoseAsBotTrans(curr);
   BotTrans prev_BT = getPoseAsBotTrans(prev);  
@@ -292,7 +293,7 @@ Eigen::Isometry3d Isometry_invert_and_compose(Eigen::Isometry3d curr, Eigen::Iso
 void StereoOdom::updateMotion(int64_t utime, int64_t prev_utime){
   
   if (vo_->getChangeReferenceFrames()){ // If we change reference frame, note the change for the next iteration.
-    std::cout << "ref frame from " << ref_utime_ << " to " << utime_cur_  << " " << (ref_utime_-utime_cur_)*1E-6 << "sec\n";
+    std::cout << "ref frame from " << ref_utime_ << " to " << utime_cur_  << " " << (utime_cur_-ref_utime_)*1E-6 << "sec\n";
     ref_utime_ = utime_cur_;
     ref_camera_pose_ = world_to_camera_;
     ref_body_pose_ = world_to_body_;

--- a/src/fovision/fovision_vo.cpp
+++ b/src/fovision/fovision_vo.cpp
@@ -346,7 +346,6 @@ void StereoOdom::updateMotion(int64_t utime, int64_t prev_utime){
 
     estimator_->publishPose(utime, "POSE_CAMERA_LEFT_ALT", world_to_camera_, Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero());
     estimator_->publishPose(utime, cl_cfg_.body_channel, world_to_body_, vel_body.translation(), Eigen::Vector3d::Zero());
-
   }
 
   // 5a. output the per-frame delta:
@@ -388,7 +387,6 @@ int pixel_convert_8u_rgb_to_8u_gray (uint8_t *dest, int dstride, int width,
   }
   return 0;
 }
-
 
 void StereoOdom::multisenseHandler(const lcm::ReceiveBuffer* rbuf,
      const std::string& channel, const  bot_core::images_t* msg){
@@ -540,7 +538,8 @@ void StereoOdom::initialiseCameraPose(Eigen::Isometry3d world_to_body_init, int6
   world_to_camera_ = world_to_body_init * body_to_camera;
   world_to_body_ = world_to_body_init;
 
-  // Needed to set these frames properly at launch: TODO, this might need to be reconsidered
+  // Needed to set these frames properly at launch: 
+  // TODO, this should be looked at again as I'm not sure this fully correct
   ref_camera_pose_ = world_to_camera_;
   ref_utime_ = utime;
   //

--- a/src/fovision/fovision_vo.cpp
+++ b/src/fovision/fovision_vo.cpp
@@ -173,7 +173,7 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
     std::cout << "Will Init internal est using VICON_pelvis_val\n";
     lcm_recv_->subscribe("VICON_pelvis_val",&StereoOdom::viconHandler,this); // |VICON_BODY|VICON_FRONTPLATE
   }else if(cl_cfg_.pose_init){
-    std::cout << "qWill Init internal est using POSE_GROUND_TRUTH\n";
+    std::cout << "Will Init internal est using POSE_GROUND_TRUTH\n";
     lcm_recv_->subscribe("POSE_GROUND_TRUTH",&StereoOdom::poseHandler,this);
   }else{
     std::cout << "Init internal est using default pose\n";

--- a/src/motion_estimate_ypr_only/imu_to_pose.cpp
+++ b/src/motion_estimate_ypr_only/imu_to_pose.cpp
@@ -6,7 +6,6 @@
 #include <lcm/lcm-cpp.hpp>
 
 #include "lcmtypes/bot_core.hpp"
-#include <lcmtypes/microstrain.hpp>
 #include <ConciseArgs>
 
 #include <Eigen/Dense>
@@ -29,8 +28,8 @@ class Pass{
     bool verbose_;
     std::string ins_channel_;
     
-    void insHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  microstrain::ins_t* msg);   
-    microstrain::ins_t lidar_msgout_;
+    void insHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::ins_t* msg);   
+    bot_core::ins_t lidar_msgout_;
 };
 
 Pass::Pass(boost::shared_ptr<lcm::LCM> &lcm_, bool verbose_,
@@ -42,7 +41,7 @@ Pass::Pass(boost::shared_ptr<lcm::LCM> &lcm_, bool verbose_,
 }
 
 
-void Pass::insHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  microstrain::ins_t* msg){
+void Pass::insHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::ins_t* msg){
   Eigen::Quaterniond meas_rot(msg->quat[0],msg->quat[1],msg->quat[2],msg->quat[3]);
   Eigen::Matrix3d meas_rotation(meas_rot);
 


### PR DESCRIPTION
major change is to output a relative transformation to a previous frame - for example one from 5 seconds back which can be used as a relative position measurement in pronto

A particular problem is that I used the following to find the relative transformation between two frames and it wasn't consistent with bot_frames:
`Eigen::Isometry3d delta_body_from_ref =  world_to_body_ * ( deltaroot_body_pose_.inverse() );`
Instead here I implement the following function:
`Eigen::Isometry3d Isometry_invert_and_compose(Eigen::Isometry3d curr, Eigen::Isometry3d prev)`
which uses libbot and is consistent bot_trans_invert_and_compose

This away of finding relative transformation is in many places and needs to be fixed.

paired with: https://github.com/openhumanoids/pronto/pull/80

FYI: @simalpha  @MarcoCar 