### PR TITLE
various fixes in RSS paper push

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(src/motion_estimate_ypr_only)
 add_subdirectory(src/blacken_image)
 
 add_subdirectory(src/tools)
+add_subdirectory(src/orbslam_writer)
 
 
 pods_install_python_script(spoof-driving-posture scripts/spoof_driving_posture.py)

--- a/scripts/plot_disparity_data.m
+++ b/scripts/plot_disparity_data.m
@@ -1,0 +1,38 @@
+%0 far/none
+%7 long range threshold
+
+%45 disparity short range threshold -----
+%60 short
+%120 disparity short
+
+% low threshold of 0.7
+% short range of 0.82 is ground at feet
+% long range of 
+% high threshold of 4m
+% end of room 20m 
+
+% = focal_length * baseline/50;
+
+close all, clear all
+x= load('example.txt');
+
+imagesc(x), colorbar
+title('orig')
+keyboard
+
+b_low = 7 % 5.53
+b_high = 45 % 0.8613
+
+x(x < b_low) = 0;
+x(x > b_high) = 0;
+imagesc(x,[b_low b_high]), colorbar
+
+focal_length = 553.6858520507812
+baseline = 0.07
+
+d = focal_length * baseline ./ x;
+
+
+
+
+figure; imagesc(d), colorbar

--- a/src/fovision/fovision.cpp
+++ b/src/fovision/fovision.cpp
@@ -8,7 +8,7 @@ FoVision::FoVision(boost::shared_ptr<lcm::LCM> &lcm_,
   int which_vo_options_):
   lcm_(lcm_), kcal_(kcal), draw_lcmgl_(draw_lcmgl_), which_vo_options_(which_vo_options_),
   odom_(kcal_->getLeftRectification(), FoVision::getOptions() ),
-  pose_(Eigen::Isometry3d::Identity())
+  pose_(Eigen::Isometry3d::Identity()), publish_fovis_stats_(false), publish_pose_(false)
 {
 
   fovis::VisualOdometryOptions vo_opts = getOptions();
@@ -21,9 +21,6 @@ FoVision::FoVision(boost::shared_ptr<lcm::LCM> &lcm_,
     bot_lcmgl_t* lcmgl = bot_lcmgl_init(lcm_->getUnderlyingLCM(), "stereo-odometry");
     visualization_ = new Visualization(lcmgl, kcal.get());
   }
-
-  publish_fovis_stats_ = 0;
-  publish_pose_ = 0;
 
 }
 
@@ -211,7 +208,6 @@ void FoVision::fovis_stats(){
 fovis::VisualOdometryOptions FoVision::getOptions()
 {
   fovis::VisualOdometryOptions vo_opts = fovis::VisualOdometry::getDefaultOptions();
-  std::cout << which_vo_options_ << " which_options\n";
 
   if(which_vo_options_ == 0){
     // not commonly used. legacy options

--- a/src/fovision/fovision.cpp
+++ b/src/fovision/fovision.cpp
@@ -21,6 +21,10 @@ FoVision::FoVision(boost::shared_ptr<lcm::LCM> &lcm_,
     bot_lcmgl_t* lcmgl = bot_lcmgl_init(lcm_->getUnderlyingLCM(), "stereo-odometry");
     visualization_ = new Visualization(lcmgl, kcal.get());
   }
+
+  publish_fovis_stats_ = 0;
+  publish_pose_ = 0;
+
 }
 
 
@@ -160,10 +164,7 @@ void FoVision::fovis_stats(){
   const fovis::MotionEstimator* me = odom_.getMotionEstimator();
   fovis::MotionEstimateStatusCode estim_status = odom_.getMotionEstimateStatus();
   
-  bool publish_fovis_stats=0;
-  bool publish_pose=0;
-
-  if (estim_status !=  fovis::NO_DATA && publish_fovis_stats) {
+  if (estim_status !=  fovis::NO_DATA && publish_fovis_stats_) {
     fovis::stats_t stats_msg;
     stats_msg.timestamp = current_timestamp_;
     stats_msg.num_matches = me->getNumMatches();
@@ -178,7 +179,7 @@ void FoVision::fovis_stats(){
   }  
   
   // publish current pose
-  if (publish_pose) {
+  if (publish_pose_) {
     
     // rotate coordinate frame so that look vector is +X, and up is +Z
     Eigen::Matrix3d M;

--- a/src/fovision/fovision.hpp
+++ b/src/fovision/fovision.hpp
@@ -99,6 +99,7 @@ public:
       return odom_.getPose();
     }
 
+    void setPublishFovisStats(bool publish_fovis_stats_in){ publish_fovis_stats_ = publish_fovis_stats_in; }
 
 private:
     boost::shared_ptr<lcm::LCM> lcm_;
@@ -109,6 +110,8 @@ private:
     fovis::StereoDepth* stereo_depth_; // typical left/right stereo
     fovis::StereoDisparity* stereo_disparity_; // left/disparity from multisense
 
+    bool publish_fovis_stats_;
+    bool publish_pose_;
 
     //fovis::PrimeSenseDepth depth_producer_; // disparity from Freenect
     //fovis::DepthImage* depth_image_; // depth from OpenNI

--- a/src/fovision/fovision_vo.cpp
+++ b/src/fovision/fovision_vo.cpp
@@ -33,8 +33,6 @@ struct CommandLineConfig
 {
   std::string camera_config; // which block from the cfg to read
   int fusion_mode;
-  bool feature_analysis;
-  int feature_analysis_publish_period; // number of frames between publishing the point features 
   std::string output_extension;
   bool output_signal;
   std::string body_channel;
@@ -42,21 +40,11 @@ struct CommandLineConfig
   std::string vicon_init_channel;
   bool pose_init; // initialize using pose_t
   std::string pose_init_channel;
-
-  std::string deltaroot_reset_channel;
-
   std::string input_channel;
   bool verbose;
   std::string in_log_fname;
   std::string param_file;
   bool draw_lcmgl;
-  int which_vo_options;
-  bool check_valid_camera_frame;
-
-  int process_skip;
-  int deltaroot_skip;
-
-  bool filter_disparity;
 };
 
 class StereoOdom{
@@ -102,7 +90,7 @@ class StereoOdom{
 
     int64_t deltaroot_utime_;
     Eigen::Isometry3d deltaroot_body_pose_; // pose of the body when the reference frames changed
-    int deltaroot_counter_;
+    int deltaroot_counter_; // Setting to -1 will reset the deltaroot during the next iteration
     int frame_counter_; // counter of ALL received frames
 
     VoEstimator* estimator_;
@@ -121,6 +109,9 @@ class StereoOdom{
 
     void initialiseCameraPose(Eigen::Isometry3d world_to_body_init, int64_t utime);
 
+    // Filter the disparity image
+    void filterDisparity(const  bot_core::images_t* msg, int w, int h);
+    // Republish image to LCM. Used to examine the disparity filtering
     void republishImage(const  bot_core::images_t* msg);
 
     bool pose_initialized_;
@@ -128,6 +119,23 @@ class StereoOdom{
     Eigen::Isometry3d world_to_camera_;
     Eigen::Isometry3d world_to_body_;
 
+
+    // Image prefiltering
+    bool filter_disparity_;
+    double filter_disparity_below_threshold_;
+    double filter_disparity_above_threshold_;
+    int filter_image_rows_above_;
+    bool publish_filtered_image_;
+
+    // Settings
+    bool publish_feature_analysis_;
+    int feature_analysis_publish_period_; // number of frames between publishing the point features 
+    bool check_valid_camera_frame_;
+
+    int deltaroot_skip_;
+    std::string deltaroot_reset_channel_;
+
+    int process_skip_;
 };    
 
 StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr<lcm::LCM> &lcm_pub_, const CommandLineConfig& cl_cfg_) : 
@@ -146,6 +154,26 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
   }
   botframes_ = bot_frames_get_global(lcm_recv_->getUnderlyingLCM(), botparam_);
   botframes_cpp_ = new bot::frames(botframes_);
+
+  // Disparity filtering
+  filter_disparity_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.filter.enabled");
+  std::cout << "Disparity Filter is " << (filter_disparity_ ? "ENABLED" : "DISABLED")  << "\n";
+  filter_disparity_below_threshold_ = bot_param_get_double_or_fail(botparam_, "visual_odometry.filter.filter_disparity_below_threshold");
+  filter_disparity_above_threshold_ = bot_param_get_double_or_fail(botparam_, "visual_odometry.filter.filter_disparity_above_threshold");
+  filter_image_rows_above_ = bot_param_get_int_or_fail(botparam_, "visual_odometry.filter.filter_image_rows_above");
+  publish_filtered_image_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.filter.publish_filtered_image");
+
+  // Feature publishing (debug only)
+  publish_feature_analysis_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.publish_feature_analysis");
+  feature_analysis_publish_period_ = bot_param_get_int_or_fail(botparam_, "visual_odometry.feature_analysis_publish_period");
+
+  check_valid_camera_frame_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.check_valid_camera_frame");
+  process_skip_ = bot_param_get_int_or_fail(botparam_, "visual_odometry.process_skip");
+
+  deltaroot_skip_ = bot_param_get_int_or_fail(botparam_, "visual_odometry.deltaroot_skip");
+  char * deltaroot_reset_channel_char = bot_param_get_str_or_fail(botparam_, "visual_odometry.deltaroot_reset_channel");
+  deltaroot_reset_channel_ = std::string(deltaroot_reset_channel_char);
+  free(deltaroot_reset_channel_char);
 
 
   pc_vis_ = new pronto_vis( lcm_pub_->getUnderlyingLCM() );
@@ -173,15 +201,13 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
   decompress_disparity_buf_ = (uint8_t*) malloc( 4*image_size_*sizeof(uint8_t));  // arbitary size chosen..
   
 
-  vo_ = new FoVision(lcm_pub_ , stereo_calibration_, cl_cfg_.draw_lcmgl, cl_cfg_.which_vo_options);
-  if ( cl_cfg_.feature_analysis ){
-    vo_->setPublishFovisStats(TRUE);
-  }
+  int which_vo_options = bot_param_get_int_or_fail(botparam_, "visual_odometry.which_vo_options");
+  vo_ = new FoVision(lcm_pub_ , stereo_calibration_, cl_cfg_.draw_lcmgl, which_vo_options);
+  vo_->setPublishFovisStats(publish_feature_analysis_);
   features_ = new VoFeatures(lcm_pub_, stereo_calibration_->getWidth(), stereo_calibration_->getHeight() );
   estimator_ = new VoEstimator(lcm_pub_ , botframes_, cl_cfg_.output_extension, cl_cfg_.camera_config );
   lcm_recv_->subscribe( cl_cfg_.input_channel,&StereoOdom::multisenseHandler,this);
 
- 
   pose_initialized_ = false;
   if (cl_cfg_.vicon_init){
     std::cout << "Will Init internal est using "  << cl_cfg_.vicon_init_channel << " message\n";
@@ -216,11 +242,13 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
     pose_initialized_ = true;
   }
   
-  lcm_recv_->subscribe( cl_cfg_.deltaroot_reset_channel,&StereoOdom::deltaResetHandler,this);
+  lcm_recv_->subscribe( deltaroot_reset_channel_ ,&StereoOdom::deltaResetHandler,this);
   deltaroot_counter_ = 0;
 
   frame_counter_ = 0;
   imgutils_ = new image_io_utils( lcm_pub_, stereo_calibration_->getWidth(), 2*stereo_calibration_->getHeight()); // extra space for stereo tasks
+
+
   cout <<"StereoOdom Constructed\n";
 }
 
@@ -229,7 +257,7 @@ int counter =0;
 void StereoOdom::featureAnalysis(){
 
   /// Incremental Feature Output:
-  if (counter% cl_cfg_.feature_analysis_publish_period  == 0 ){
+  if (counter% feature_analysis_publish_period_  == 0 ){
     features_->setFeatures(vo_->getMatches(), vo_->getNumMatches() , utime_cur_);
     features_->setCurrentImage(left_buf_);
     //features_->setCurrentImages(left_buf_, right_buf_);
@@ -328,7 +356,7 @@ void StereoOdom::updateMotion(int64_t utime, int64_t prev_utime){
   // 0. Reset the deltaroot. This can happen either after a set number of frames
   // or after a failure of the VO algorithm
   deltaroot_counter_++;
-  if(deltaroot_counter_%cl_cfg_.deltaroot_skip == 0){
+  if(deltaroot_counter_%deltaroot_skip_ == 0){
     std::cout.precision(17);
     std::cout << "Delta root frame changed from " << (deltaroot_utime_*1E-6) << " to " << (utime_cur_*1E-6)  << " " << (utime_cur_-deltaroot_utime_)*1E-6 << "sec\n";
     std::cout.precision(6);
@@ -366,10 +394,10 @@ void StereoOdom::updateMotion(int64_t utime, int64_t prev_utime){
     estimator_->publishPose(utime, cl_cfg_.body_channel, world_to_body_, vel_body.translation(), Eigen::Vector3d::Zero());
   }
 
-
+  // 4a. Exist of the most recent VO frame was a failure.
   if (delta_status != fovis::SUCCESS){
-    std::cout << "Not sending delta travelled, resetting\n";
-    deltaroot_counter_ = -1;
+    std::cout << "Not sending delta travelled, resetting deltaroot\n";
+    deltaroot_counter_ = -1; // Setting to -1 will reset the deltaroot during the next iteration
     return;
   }
 
@@ -380,7 +408,6 @@ void StereoOdom::updateMotion(int64_t utime, int64_t prev_utime){
   // 5b. output the per-keyframe delta for the last period
   fovis::update_t update_msg = vo_->get_delta_translation_msg(delta_body_from_ref, delta_camera_cov, utime, deltaroot_utime_);
   lcm_pub_->publish("VO_DELTA_BODY_SINCE_REF", &update_msg);
-  //std::cout << delta_body_from_ref.translation().transpose() << "\n";
 
 
   if (1==0){
@@ -416,7 +443,7 @@ int pixel_convert_8u_rgb_to_8u_gray (uint8_t *dest, int dstride, int width,
 void StereoOdom::multisenseHandler(const lcm::ReceiveBuffer* rbuf,
      const std::string& channel, const  bot_core::images_t* msg){
   frame_counter_++;
-  if (frame_counter_% cl_cfg_.process_skip  != 0){
+  if (frame_counter_% process_skip_  != 0){
     return;
   }
 
@@ -444,7 +471,7 @@ void StereoOdom::multisenseHandler(const lcm::ReceiveBuffer* rbuf,
   }
   updateMotion(msg->utime, utime_prev_);
 
-  if(cl_cfg_.feature_analysis)
+  if(publish_feature_analysis_)
     featureAnalysis();
 
 }
@@ -487,35 +514,39 @@ void StereoOdom::multisenseLDHandler(const lcm::ReceiveBuffer* rbuf,
   disparity = disparity_orig / 16.0;
 
 
-  // Filter the data to remove far away depth and the crash bar (from hyq)
-  // TODO: measure how long this takes, it can be implemented more efficiently
-  // depth  =  focal_length * base  / disparity
-  float disp_low_threshold = 7.0; // 5.5m  use some where between 7 and 15
-  float disp_high_threshold = 75.0; // 0.86=45disp | 0.75m=75disp
-  int row_filter = 720; // filter the lower part of the image
-  if (cl_cfg_.filter_disparity){
-    for(int v=0; v<h; v++) { // t2b
-      for(int u=0; u<w; u++ ) {  //l2r
+  if (filter_disparity_){
+    // Filter the data to remove far away depth and the crash bar (from hyq)
+    filterDisparity(msg, w, h);
+  }
+ 
+  return;
+}
 
-        if (v > row_filter){
+void StereoOdom::filterDisparity(const  bot_core::images_t* msg, int w, int h){
+  // TODO: measure how long this takes, it can be implemented more efficiently
+
+  for(int v=0; v<h; v++) { // t2b
+    for(int u=0; u<w; u++ ) {  //l2r
+
+      if (v > filter_image_rows_above_){
+        disparity_buf_[w*v + u] = 0;
+        //left_buf_[w*v + u] = 0;
+      }else{
+        float val = disparity_buf_[w*v + u];
+        if (val < filter_disparity_below_threshold_){
           disparity_buf_[w*v + u] = 0;
-          //left_buf_[w*v + u] = 0;
-        }else{
-          float val = disparity_buf_[w*v + u];
-          if (val < disp_low_threshold){
-            disparity_buf_[w*v + u] = 0;
-            //left_buf_[w*v + u] = 100;
-          } else if (val > disp_high_threshold){
-            disparity_buf_[w*v + u] = 0;
-            //left_buf_[w*v + u] = 100;
-          }
+          //left_buf_[w*v + u] = 100;
+        } else if (val > filter_disparity_above_threshold_){
+          disparity_buf_[w*v + u] = 0;
+          //left_buf_[w*v + u] = 100;
         }
       }
     }
   }
-  // republishImage(msg);
- 
-  return;
+
+  if (publish_filtered_image_)
+    republishImage(msg);
+
 }
 
 
@@ -533,7 +564,7 @@ void StereoOdom::republishImage(const  bot_core::images_t* msg){
   msgout_image.data.resize( width*height );
   memcpy(msgout_image.data.data(), left_buf_, width*height );
   msgout_image.nmetadata =0;
-  lcm_pub_->publish("MMM", &msgout_image);
+  lcm_pub_->publish("CAMERA_LEFT_FILTERED", &msgout_image);
 
   bot_core::image_t msgout_depth;
   msgout_depth.utime = msg->utime;
@@ -545,7 +576,6 @@ void StereoOdom::republishImage(const  bot_core::images_t* msg){
   msgout_depth.data.resize( 2*width*height );
   memcpy(msgout_depth.data.data(), decompress_disparity_buf_, 2*width*height );
   msgout_depth.nmetadata =0;
-  //lcm_pub_->publish("MMM2", &msgout_depth);
 
   bot_core::images_t msgo;
   msgo.utime = msg->utime;
@@ -580,7 +610,7 @@ void StereoOdom::republishImage(const  bot_core::images_t* msg){
 void StereoOdom::deltaResetHandler(const lcm::ReceiveBuffer* rbuf,
      const std::string& channel, const  bot_core::pose_t* msg){
   std::cout << "Got message on channel " << channel << ", will reset deltaroot\n";
-  deltaroot_counter_ = -1;
+  deltaroot_counter_ = -1; // Setting to -1 will reset the deltaroot during the next iteration
 }
 
 
@@ -641,7 +671,7 @@ static inline bot_core::pose_t getPoseAsBotPose(Eigen::Isometry3d pose, int64_t 
 
 void StereoOdom::initialiseCameraPose(Eigen::Isometry3d world_to_body_init, int64_t utime){
 
-  if (cl_cfg_.check_valid_camera_frame){
+  if (check_valid_camera_frame_){
     // Because body to CAMERA comes through FK, need to get an updated frame (BODY_TO_HEAD)
     int64_t timestamp;
     int status  = bot_frames_get_latest_timestamp(botframes_, 
@@ -717,8 +747,7 @@ int main(int argc, char **argv){
   cl_cfg.input_channel = "MULTISENSE_CAMERA";
   cl_cfg.output_signal = FALSE;
   cl_cfg.body_channel = "POSE_BODY_USING_CAMERA";
-  cl_cfg.feature_analysis = FALSE; 
-  cl_cfg.vicon_init = FALSE;
+    cl_cfg.vicon_init = FALSE;
   cl_cfg.vicon_init_channel = "VICON_pelvis_val";
   cl_cfg.pose_init = FALSE;
   cl_cfg.pose_init_channel = "POSE_BODY_ALT";
@@ -727,23 +756,12 @@ int main(int argc, char **argv){
   cl_cfg.in_log_fname = "";
   std::string param_file = ""; // actual file
   cl_cfg.param_file = ""; // full path to file
-  cl_cfg.feature_analysis_publish_period = 1; // 5
   cl_cfg.draw_lcmgl = FALSE;
-  cl_cfg.which_vo_options = 1;
-  cl_cfg.check_valid_camera_frame = TRUE;
-
-  cl_cfg.deltaroot_reset_channel = "DELTA_RESET";
-
-  cl_cfg.process_skip = 1;
-  cl_cfg.deltaroot_skip = 50;
-  cl_cfg.filter_disparity = TRUE;
 
   ConciseArgs parser(argc, argv, "fovision-odometry");
   parser.add(cl_cfg.camera_config, "c", "camera_config", "Camera Config block to use: MULTISENSE_CAMERA, stereo, stereo_with_letterbox");
   parser.add(cl_cfg.output_signal, "p", "output_signal", "Output POSE_CAMERA_LEFT_ALT and body estimates");
   parser.add(cl_cfg.body_channel, "b", "body_channel", "body frame estimate (typically POSE_BODY)");
-  parser.add(cl_cfg.feature_analysis, "f", "feature_analysis", "Publish Feature Analysis Data");
-  parser.add(cl_cfg.feature_analysis_publish_period, "fp", "feature_analysis_publish_period", "Publish features with this period");    
   parser.add(cl_cfg.vicon_init, "vi", "vicon_init", "Bootstrap internal estimate using a vicon rigid_transform_t msg");
   parser.add(cl_cfg.vicon_init_channel, "vc", "vicon_init_channel", "If initialising with a rigid_transform_t msg, use this channel");
   parser.add(cl_cfg.pose_init, "pi", "pose_init", "Bootstrap internal estimate using a pose_t message");
@@ -754,16 +772,9 @@ int main(int argc, char **argv){
   parser.add(cl_cfg.in_log_fname, "L", "in_log_fname", "Process this log file");
   parser.add(param_file, "P", "param_file", "Pull params from this file instead of LCM");
   parser.add(cl_cfg.draw_lcmgl, "g", "lcmgl", "Draw LCMGL visualization of features");
-  parser.add(cl_cfg.which_vo_options, "n", "which_vo_options", "Which set of VO options to use [1=slow,2=fast]");
-  parser.add(cl_cfg.check_valid_camera_frame, "k", "check_valid_camera_frame", "Check that BODY-to-HEAD has been updated");
-  parser.add(cl_cfg.process_skip, "s", "process_skip", "Number of frames to skip per VO frame processed");
-  parser.add(cl_cfg.deltaroot_skip, "d", "deltaroot_skip", "Number of frames to skip between deltaroot updates");
-  parser.add(cl_cfg.deltaroot_reset_channel, "r", "deltaroot_reset_channel", "Channel to listen for a delta reset command");
-  parser.add(cl_cfg.filter_disparity, "y", "filter_disparity", "Filter disparities using hard coded settings, typically true");  
   parser.parse();
   cout << cl_cfg.fusion_mode << " is fusion_mode\n";
   cout << cl_cfg.camera_config << " is camera_config\n";
-  cout << (int) cl_cfg.filter_disparity << " is filter_disparity\n";
 
   cl_cfg.param_file = std::string(getConfigPath()) +'/' + std::string(param_file);
   if (param_file.empty()) { // get param from lcm

--- a/src/fovision/fovision_vo.cpp
+++ b/src/fovision/fovision_vo.cpp
@@ -174,6 +174,9 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
   
 
   vo_ = new FoVision(lcm_pub_ , stereo_calibration_, cl_cfg_.draw_lcmgl, cl_cfg_.which_vo_options);
+  if ( cl_cfg_.feature_analysis ){
+    vo_->setPublishFovisStats(TRUE);
+  }
   features_ = new VoFeatures(lcm_pub_, stereo_calibration_->getWidth(), stereo_calibration_->getHeight() );
   estimator_ = new VoEstimator(lcm_pub_ , botframes_, cl_cfg_.output_extension, cl_cfg_.camera_config );
   lcm_recv_->subscribe( cl_cfg_.input_channel,&StereoOdom::multisenseHandler,this);

--- a/src/orbslam_writer/CMakeLists.txt
+++ b/src/orbslam_writer/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_definitions( -ggdb3 -std=gnu99 )
+
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+project(orbslam_writer)
+
+
+add_executable(se-orbslam-writer orbslam_writer.cpp  )
+pods_use_pkg_config_packages(se-orbslam-writer
+  image_io_utils opencv eigen3)
+pods_install_executables(se-orbslam-writer )

--- a/src/orbslam_writer/orbslam_writer.cpp
+++ b/src/orbslam_writer/orbslam_writer.cpp
@@ -1,0 +1,127 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <iostream>
+#include <fstream>      // std::ifstream, std::ofstream
+
+#include <opencv/cv.h>
+#include <opencv/highgui.h>
+
+#include <boost/shared_ptr.hpp>
+#include <lcm/lcm-cpp.hpp>
+
+#include "lcmtypes/bot_core.hpp"
+#include <image_io_utils/image_io_utils.hpp> // to simplify jpeg/zlib compression and decompression
+#include <ConciseArgs>
+using namespace cv;
+using namespace std;
+
+class Pass{
+  public:
+    Pass(boost::shared_ptr<lcm::LCM> &lcm_, bool verbose_,
+         std::string input_channel_, std::string output_folder_);
+    
+    ~Pass(){
+      std::cout << "finish\n";
+      timestamp_file_.close();
+
+    }    
+  private:
+    boost::shared_ptr<lcm::LCM> lcm_;
+    bool verbose_;
+    std::string input_channel_;
+    std::string output_folder_;
+    image_io_utils*  imgutils_;
+    uint8_t* img_buf_; 
+    uint8_t* rgb_compress_buffer_;
+
+    ofstream timestamp_file_;
+
+    
+    void imagesHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::images_t* msg);
+};
+
+Pass::Pass(boost::shared_ptr<lcm::LCM> &lcm_, bool verbose_,
+         std::string input_channel_, std::string output_folder_):
+    lcm_(lcm_), verbose_(verbose_), 
+    input_channel_(input_channel_), output_folder_(output_folder_){
+  lcm_->subscribe( input_channel_ ,&Pass::imagesHandler,this);
+
+  // left these numbers very large:
+  img_buf_= (uint8_t*) malloc(3* 1524  * 1544);
+  imgutils_ = new image_io_utils( lcm_, 
+                                  1524, 
+                                  3*1544 );  
+
+  rgb_compress_buffer_= (uint8_t*) malloc(3* 1524  * 1544);
+
+  std::stringstream ss;
+  ss << output_folder_ << "timestamps.txt";
+
+  timestamp_file_.open (ss.str().c_str() );
+
+
+}
+
+
+void Pass::imagesHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::images_t* msg){
+  std::cout << "1got " << channel << "\n";
+
+  int w = msg->images[0].width;
+  int h = msg->images[0].height;
+  int n_colors =3;
+  
+  imgutils_->decodeImageToGray( & msg->images[0], img_buf_);
+  cv::Mat img(cv::Size( w, h),CV_8UC1);
+  img.data = img_buf_;
+  std::stringstream ss;
+  ss << output_folder_ << "left_cam/" << msg->utime << ".png";
+  std::cout << ss.str() << "\n";
+  //cv::cvtColor(img, img, CV_RGB2BGR);
+  imwrite( ss.str(), img);
+
+
+
+  imgutils_->decodeImageToGray( & msg->images[1], img_buf_);
+  cv::Mat img2(cv::Size( w, h),CV_8UC1);
+  img2.data = img_buf_;
+  std::stringstream ss2;
+  ss2 << output_folder_ << "right_cam/" << msg->utime << ".png";
+  std::cout << ss2.str() << "\n";
+  //cv::cvtColor(img, img, CV_RGB2BGR);
+  imwrite( ss2.str(), img2);
+
+
+
+  timestamp_file_ << msg->utime << "\n";
+  timestamp_file_.flush();
+
+}
+
+
+int main( int argc, char** argv ){
+  ConciseArgs parser(argc, argv, "blacken-image");
+  bool verbose=false;
+  string input_channel="MULTISENSE_CAMERA";
+  string output_folder="/media/mfallon/bay_drive/hyq_stereo/";
+  parser.add(verbose, "v", "verbose", "Verbosity");
+  parser.add(input_channel, "l", "input_channel", "Incoming channel");
+  parser.add(output_folder, "o", "output_folder", "Output folder");
+  parser.parse();
+  cout << verbose << " is verbose\n";
+  cout << input_channel << " is input_channel\n";
+  cout << output_folder << " is output_folder\n";
+  
+  boost::shared_ptr<lcm::LCM> lcm(new lcm::LCM);
+  if(!lcm->good()){
+    std::cerr <<"ERROR: lcm is not good()" <<std::endl;
+  }
+
+
+  
+  Pass app(lcm,verbose,input_channel, output_folder);
+  cout << "Ready to convert from imu to pose" << endl << "============================" << endl;
+  while(0 == lcm->handle());
+
+  std::cout << "exit\n";
+  return 0;
+}

--- a/src/vofeatures/vofeatures.cpp
+++ b/src/vofeatures/vofeatures.cpp
@@ -184,7 +184,7 @@ void VoFeatures::doFeatureProcessing(bool useCurrent, bool writeOutput){
 
 void VoFeatures::drawFeaturesOnImage(cv::Mat &img, std::vector<ImageFeature> &features,
     std::vector<int> &feature_indices){
-  CvScalar color_out = CV_RGB(255,0,0);
+  CvScalar color_out = CV_RGB(255,255,255);
   for (size_t j=0;j< features.size(); j++){
     if (feature_indices[j]){
       cv::Point p0;


### PR DESCRIPTION
- listen to deltaroot reset (from AICP)
- reset deltaroot if the vo fails briefly
- starts to use a config file instead of command line arguments
- filter disparity thats too near or too far
- adds a quick LCM writer for orbslam data