### PR TITLE
[VO-Fusion] Disparity filter, fix for publisher rate

### DIFF
--- a/src/fovision/fovision_fusion.cpp
+++ b/src/fovision/fovision_fusion.cpp
@@ -429,12 +429,12 @@ void StereoOdom::filterDisparity(const  bot_core::images_t* msg, int w, int h){
 
       if (v > filter_image_rows_above_){
         disparity_buf_[w*v + u] = 0;
-        //left_buf_[w*v + u] = 0;
+        left_buf_[w*v + u] = 0;
       }else{
         float val = disparity_buf_[w*v + u];
         if (val < filter_disparity_below_threshold_ || val > filter_disparity_above_threshold_){
           disparity_buf_[w*v + u] = 0;
-          //left_buf_[w*v + u] = 100;
+          left_buf_[w*v + u] = 100;
         }
       }
     }

--- a/src/fovision/fovision_fusion.cpp
+++ b/src/fovision/fovision_fusion.cpp
@@ -117,6 +117,18 @@ class StereoOdom{
     // Most recent IMU-derived body orientation
     Eigen::Quaterniond local_to_body_orientation_from_imu_;
 
+    // Filter the disparity image
+    void filterDisparity(const  bot_core::images_t* msg, int w, int h);
+    // Republish image to LCM. Used to examine the disparity filtering
+    void republishImage(const  bot_core::images_t* msg);
+
+    // Image prefiltering
+    bool filter_disparity_;
+    double filter_disparity_below_threshold_;
+    double filter_disparity_above_threshold_;
+    int filter_image_rows_above_;
+    bool publish_filtered_image_;
+
 };    
 
 StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr<lcm::LCM> &lcm_pub_, const CommandLineConfig& cl_cfg_) : 
@@ -140,6 +152,14 @@ StereoOdom::StereoOdom(boost::shared_ptr<lcm::LCM> &lcm_recv_, boost::shared_ptr
   config_ = new voconfig::KmclConfiguration(botparam_, cl_cfg_.camera_config);
   boost::shared_ptr<fovis::StereoCalibration> stereo_calibration_;
   stereo_calibration_ = boost::shared_ptr<fovis::StereoCalibration>(config_->load_stereo_calibration());
+
+  // Disparity filtering
+  filter_disparity_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.filter.enabled");
+  std::cout << "Disparity Filter is " << (filter_disparity_ ? "ENABLED" : "DISABLED")  << "\n";
+  filter_disparity_below_threshold_ = bot_param_get_double_or_fail(botparam_, "visual_odometry.filter.filter_disparity_below_threshold");
+  filter_disparity_above_threshold_ = bot_param_get_double_or_fail(botparam_, "visual_odometry.filter.filter_disparity_above_threshold");
+  filter_image_rows_above_ = bot_param_get_int_or_fail(botparam_, "visual_odometry.filter.filter_image_rows_above");
+  publish_filtered_image_ = bot_param_get_boolean_or_fail(botparam_, "visual_odometry.filter.publish_filtered_image");
 
   // Allocate various buffers:
   image_size_ = stereo_calibration_->getWidth() * stereo_calibration_->getHeight();
@@ -393,9 +413,94 @@ void StereoOdom::multisenseLDHandler(const lcm::ReceiveBuffer* rbuf,
   cv::Mat_<float> disparity(h, w, &(disparity_buf_[0]));
   disparity = disparity_orig / 16.0;
 
+  if (filter_disparity_){
+    // Filter the data to remove far away depth and the crash bar (from hyq)
+    filterDisparity(msg, w, h);
+  }
+
   return;
 }
 
+void StereoOdom::filterDisparity(const  bot_core::images_t* msg, int w, int h){
+  // TODO: measure how long this takes, it can be implemented more efficiently
+
+  for(int v=0; v<h; v++) { // t2b
+    for(int u=0; u<w; u++ ) {  //l2r
+
+      if (v > filter_image_rows_above_){
+        disparity_buf_[w*v + u] = 0;
+        //left_buf_[w*v + u] = 0;
+      }else{
+        float val = disparity_buf_[w*v + u];
+        if (val < filter_disparity_below_threshold_ || val > filter_disparity_above_threshold_){
+          disparity_buf_[w*v + u] = 0;
+          //left_buf_[w*v + u] = 100;
+        }
+      }
+    }
+  }
+
+  if (publish_filtered_image_)
+    republishImage(msg);
+
+}
+
+
+void StereoOdom::republishImage(const  bot_core::images_t* msg){
+  int width = msg->images[0].width;
+  int height = msg->images[0].height;
+
+  bot_core::image_t msgout_image;
+  msgout_image.utime = msg->utime;
+  msgout_image.width = width;
+  msgout_image.height = height;
+  msgout_image.row_stride = width;
+  msgout_image.size = width*height;
+  msgout_image.pixelformat = bot_core::image_t::PIXEL_FORMAT_GRAY;
+  msgout_image.data.resize( width*height );
+  memcpy(msgout_image.data.data(), left_buf_, width*height );
+  msgout_image.nmetadata =0;
+  lcm_pub_->publish("CAMERA_LEFT_FILTERED", &msgout_image);
+
+  bot_core::image_t msgout_depth;
+  msgout_depth.utime = msg->utime;
+  msgout_depth.width = width;
+  msgout_depth.height = height;
+  msgout_depth.row_stride = 2*width;
+  msgout_depth.size = 2*width*height;
+  msgout_depth.pixelformat = bot_core::image_t::PIXEL_FORMAT_GRAY; // false, no info
+  msgout_depth.data.resize( 2*width*height );
+  memcpy(msgout_depth.data.data(), decompress_disparity_buf_, 2*width*height );
+  msgout_depth.nmetadata =0;
+
+  bot_core::images_t msgo;
+  msgo.utime = msg->utime;
+  msgo.n_images = 2;
+  msgo.images.resize(2);
+  msgo.image_types.resize(2);
+  msgo.image_types[0] = bot_core::images_t::LEFT;
+  msgo.image_types[1] = bot_core::images_t::DISPARITY;
+  msgo.images[0] = msg->images[0];
+  msgo.images[1] = msgout_depth;
+  lcm_pub_->publish( "CAMERA_FILTERED" , &msgo);
+
+  /*
+  ofstream myfile;
+  myfile.open ("example.txt");
+  //myfile << "Writing this to a file.\n";
+  for(int v=0; v<h; v++) { // t2b
+    std::stringstream ss;
+    for(int u=0; u<w; u++ ) {  //l2r
+      ss << (float) disparity_buf_[w*v + u] << " ";
+      // cout <<j2 << " " << v << " " << u << " | " <<  points(v,u)[0] << " " <<  points(v,u)[1] << " " <<  points(v,u)[1] << "\n";
+      // std::cout <<  << " " << v << " " << u << "\n";
+    }
+    myfile << ss.str() << "\n";
+  }
+  myfile.close();
+  std::cout << "writing\n";
+  */
+}
 
 void StereoOdom::multisenseLRHandler(const lcm::ReceiveBuffer* rbuf,
      const std::string& channel, const  bot_core::images_t* msg){

--- a/src/fovision/fovision_fusion.cpp
+++ b/src/fovision/fovision_fusion.cpp
@@ -460,7 +460,7 @@ void StereoOdom::republishImage(const  bot_core::images_t* msg){
   msgout_image.data.resize( width*height );
   memcpy(msgout_image.data.data(), left_buf_, width*height );
   msgout_image.nmetadata =0;
-  lcm_pub_->publish("CAMERA_LEFT_FILTERED", &msgout_image);
+  lcm_pub_->publish("MULTISENSE_CAMERA_LEFT_FILTERED", &msgout_image);
 
   bot_core::image_t msgout_depth;
   msgout_depth.utime = msg->utime;
@@ -480,9 +480,9 @@ void StereoOdom::republishImage(const  bot_core::images_t* msg){
   msgo.image_types.resize(2);
   msgo.image_types[0] = bot_core::images_t::LEFT;
   msgo.image_types[1] = bot_core::images_t::DISPARITY;
-  msgo.images[0] = msg->images[0];
+  msgo.images[0] = msgout_image;
   msgo.images[1] = msgout_depth;
-  lcm_pub_->publish( "CAMERA_FILTERED" , &msgo);
+  lcm_pub_->publish( "MULTISENSE_CAMERA_FILTERED" , &msgo);
 
   /*
   ofstream myfile;


### PR DESCRIPTION
Added disparity filter that reads from config.
Publisher in fuseInternal() now always publishes with latest timestamp.
Moved the publisher to publish on received camera image, rather than from the IMU handler.